### PR TITLE
WDP200601-20

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import store from './redux/store';
 import './styles/bootstrap.scss';
 import './styles/global.scss';
 
-import MainLayout from './components/layout/MainLayout/MainLayout';
+import MainLayout from './components/layout/MainLayout/MainLayoutContainer';
 import Homepage from './components/views/Homepage/Homepage';
 import ProductList from './components/views/ProductList/ProductList';
 import ProductPage from './components/views/ProductPage/ProductPage';

--- a/src/components/features/Feedback/Feedback.js
+++ b/src/components/features/Feedback/Feedback.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import styles from './Feedback.module.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuoteRight } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+
+class Feedback extends React.Component {
+  state = {
+    activePage: 0,
+  };
+
+  handlePageChange = newPage => {
+    setTimeout(() => this.setState({ activePage: newPage }), 700);
+  };
+
+  getDotsList = () => {
+    const { activePage } = this.state;
+    const dots = [];
+
+    for (let i = 0; i < 3; i++) {
+      dots.push(
+        <li>
+          <a
+            onClick={() => this.handlePageChange(i)}
+            className={i === activePage && styles.active}
+          >
+            page {i}
+          </a>
+        </li>
+      );
+    }
+    return dots;
+  };
+
+  render() {
+    const { ratings } = this.props;
+
+    return (
+      <div className={styles.root}>
+        <div className='container'>
+          <div className={styles.panelBar}>
+            <div className='row no-gutters align-items-end'>
+              <div className={'col-3 ' + styles.heading}>
+                <h3>Client Feedback</h3>
+              </div>
+              <div className={'col-auto ' + styles.dots}>
+                <ul>{this.getDotsList()}</ul>
+              </div>
+            </div>
+          </div>
+
+          <div className='row'>
+            <div className={'col ' + styles.quote}>
+              <FontAwesomeIcon icon={faQuoteRight} className={styles.quotes}>
+                {' '}
+                stars
+              </FontAwesomeIcon>
+              <div className={styles.rating}>{ratings[0].rating}</div>
+              <div className={styles.person}>
+                <div className={styles.person_image}>
+                  <img src={ratings[0].image} alt={ratings[0].occupation}></img>
+                </div>
+                <div className={styles.person_name}>
+                  <h5>{ratings[0].person}</h5>
+                  <p>{ratings[0].occupation}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+Feedback.propTypes = {
+  ratings: PropTypes.arrayOf(
+    PropTypes.shape({
+      image: PropTypes.string,
+      occupation: PropTypes.string,
+      rating: PropTypes.string,
+      person: PropTypes.string,
+    })
+  ),
+};
+
+export default Feedback;

--- a/src/components/features/Feedback/Feedback.module.scss
+++ b/src/components/features/Feedback/Feedback.module.scss
@@ -1,0 +1,117 @@
+@import "../../../styles/settings.scss";
+
+.root {
+  .panelBar {
+    margin-bottom: 30px;
+    position: relative;
+
+    :global(.row) {
+      border-bottom: 4px solid  $newFurniture-line;
+    }
+
+    .heading {
+      position: relative;
+
+      h3 {
+        color: $primary;
+        text-transform: uppercase;
+        font-size: 20px;
+        line-height: 38px;
+        margin: 0;
+        letter-spacing: 1px;
+      }
+
+      &::before {
+        content: "";
+        position: absolute;
+        bottom: -4px;
+        left: 0;
+        width: 45px;
+        border-bottom: 4px solid $primary;
+      }
+    }
+  }
+}
+
+.dots {
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  ul {
+    margin: 0;
+    padding: 0 0 0 1rem;
+    list-style: none;
+    background-color: $newFurniture-dots-bg;
+    transform: translateY(15px);
+
+    li {
+      display: inline-block;
+      margin-left: 0.5rem;
+
+      a {
+        display: block;
+        width: 13px;
+        height: 13px;
+        border-radius: 6px;
+        background-color: $newFurniture-dots-color;
+        font-size: 0;
+
+        &.active,
+        &:hover {
+          background-color: $primary;
+        }
+      }
+    }
+  }
+}
+
+.quote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 60px;
+
+  .quotes {
+    font-size: 20px;
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  .rating {
+    font-size: 14px;
+    color: black;
+    text-align: center;
+    margin-bottom: 20px;
+    width: 80%;
+  }
+
+  .person {
+    display: flex;
+    color: black;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+
+
+    h5 {
+      font-weight: 800;
+      font-size: 15px;
+      margin: 0;
+      right: 15px;
+    }
+
+    p {
+      font-size: 14px;
+      margin: 0;
+      color: grey;
+    }
+
+    .person_image img {
+      width: 55px;
+      height: 55px;
+      margin-right: 20px;
+      object-fit: cover;
+    }
+  }
+}

--- a/src/components/features/Feedback/FeedbackContainer.js
+++ b/src/components/features/Feedback/FeedbackContainer.js
@@ -1,0 +1,9 @@
+import Feedback from './Feedback';
+import { connect } from 'react-redux';
+import { getAll } from '../../../redux/ratingsRedux';
+
+const mapStateToProps = state => ({
+  ratings: getAll(state),
+});
+
+export default connect(mapStateToProps)(Feedback);

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -47,6 +47,7 @@ class NewFurniture extends React.Component {
     const { activeCategory, activePage } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
+
     const pagesCount = Math.ceil(
       categoryProducts.length / this.productsOnPage(viewport)
     );

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -43,11 +43,13 @@ class NewFurniture extends React.Component {
   }
 
   render() {
-    const { categories, products } = this.props;
+    const { categories, products, viewport } = this.props;
     const { activeCategory, activePage } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / this.productsOnPage);
+    const pagesCount = Math.ceil(
+      categoryProducts.length / this.productsOnPage(viewport)
+    );
 
     const newPages = [];
     const dots = [];

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -67,11 +67,16 @@ class NewFurniture extends React.Component {
       );
       newPages.push(
         <div className={'row' + ' ' + styles.changeForNewPage}>
-          {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-            <div key={item.id} className='col-3'>
-              <ProductBox {...item} />
-            </div>
-          ))}
+          {categoryProducts
+            .slice(
+              activePage * this.productsOnPage(viewport),
+              (activePage + 1) * this.productsOnPage(viewport)
+            )
+            .map(item => (
+              <div key={item.id} className='col-lg-3 col-md-6 col-sm-12'>
+                <ProductBox {...item} />
+              </div>
+            ))}
         </div>
       );
     }

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -29,11 +29,21 @@ class NewFurniture extends React.Component {
   }
 
   render() {
-    const { categories, products } = this.props;
+    const { categories, products, viewport } = this.props;
     const { activeCategory, activePage } = this.state;
 
+    let productsOnPage;
+
+    if (viewport === 'desktop') {
+      productsOnPage = 8;
+    } else if (viewport === 'tablet') {
+      productsOnPage = 2;
+    } else {
+      productsOnPage = 1;
+    }
+
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / 8);
+    const pagesCount = Math.ceil(categoryProducts.length / productsOnPage);
 
     const newPages = [];
     const dots = [];
@@ -117,6 +127,7 @@ NewFurniture.propTypes = {
       newFurniture: PropTypes.bool,
     })
   ),
+  viewport: PropTypes.string,
 };
 
 NewFurniture.defaultProps = {

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -48,9 +48,7 @@ class NewFurniture extends React.Component {
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
 
-    const pagesCount = Math.ceil(
-      categoryProducts.length / this.productsOnPage(viewport)
-    );
+    const pagesCount = Math.ceil(categoryProducts.length / 8);
 
     const newPages = [];
     const dots = [];
@@ -67,7 +65,7 @@ class NewFurniture extends React.Component {
         </li>
       );
       newPages.push(
-        <div className={'row' + ' ' + styles.changeForNewPage}>
+        <div className={'row ' + styles.changeForNewPage}>
           {categoryProducts
             .slice(
               activePage * this.productsOnPage(viewport),

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -28,10 +28,7 @@ class NewFurniture extends React.Component {
     this.setState({ activeCategory: newCategory });
   }
 
-  render() {
-    const { categories, products, viewport } = this.props;
-    const { activeCategory, activePage } = this.state;
-
+  productsOnPage(viewport) {
     let productsOnPage;
 
     if (viewport === 'desktop') {
@@ -42,8 +39,15 @@ class NewFurniture extends React.Component {
       productsOnPage = 1;
     }
 
+    return productsOnPage;
+  }
+
+  render() {
+    const { categories, products } = this.props;
+    const { activeCategory, activePage } = this.state;
+
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / productsOnPage);
+    const pagesCount = Math.ceil(categoryProducts.length / this.productsOnPage);
 
     const newPages = [];
     const dots = [];

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -102,8 +102,14 @@
   }
 }
 
-// @media (max-width: 575.98px) {
-//   .heading {
-//     margin-bottom: 20px;
-//   }
-//  }
+@media (max-width: 575.98px) {
+  .root {
+    .heading {
+      margin-bottom: 20px;
+    }
+
+    .dots {
+      position: relative !important;
+    }
+  }
+}

--- a/src/components/features/NewFurniture/NewFurnitureContainer.js
+++ b/src/components/features/NewFurniture/NewFurnitureContainer.js
@@ -8,6 +8,7 @@ import { getNew } from '../../../redux/productsRedux.js';
 const mapStateToProps = state => ({
   categories: getAll(state),
   products: getNew(state),
+  viewport: state.viewport,
 });
 
 export default connect(mapStateToProps)(NewFurniture);

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -17,9 +17,7 @@ const checkViewportWidth = () => {
 const MainLayout = ({ children, changeViewportWidth }) => {
   useEffect(() => {
     changeViewportWidth(checkViewportWidth());
-    window.addEventListener('resize', newWidth =>
-      changeViewportWidth(checkViewportWidth(newWidth))
-    );
+    window.addEventListener('resize', () => changeViewportWidth(checkViewportWidth()));
   });
 
   return (

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -18,7 +18,9 @@ const MainLayout = ({ children, changeViewportWidth }) => {
   useEffect(() => {
     changeViewportWidth(checkViewportWidth());
     window.addEventListener('resize', () => changeViewportWidth(checkViewportWidth()));
-  });
+    return () =>
+      window.removeEventListener('resize', changeViewportWidth(checkViewportWidth()));
+  }, [changeViewportWidth]);
 
   return (
     <div>

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -1,19 +1,39 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
 
-const MainLayout = ({ children }) => (
-  <div>
-    <Header />
-    {children}
-    <Footer />
-  </div>
-);
+const checkViewportWidth = () => {
+  if (window.innerWidth < 768) {
+    return 'mobile';
+  } else if (window.innerWidth >= 768 && window.innerWidth < 992) {
+    return 'tablet';
+  } else {
+    return 'desktop';
+  }
+};
+
+const MainLayout = ({ children, changeViewportWidth }) => {
+  useEffect(() => {
+    changeViewportWidth(checkViewportWidth());
+    window.addEventListener('resize', newWidth =>
+      changeViewportWidth(checkViewportWidth(newWidth))
+    );
+  });
+
+  return (
+    <div>
+      <Header />
+      {children}
+      <Footer />
+    </div>
+  );
+};
 
 MainLayout.propTypes = {
   children: PropTypes.node,
+  changeViewportWidth: PropTypes.func,
 };
 
 export default MainLayout;

--- a/src/components/layout/MainLayout/MainLayoutContainer.js
+++ b/src/components/layout/MainLayout/MainLayoutContainer.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+
+import MainLayout from './MainLayout';
+
+import {
+  getViewportWidth,
+  createAction_changeViewportWidth,
+} from '../../../redux/viewportRedux';
+
+const mapStateToProps = state => ({
+  viewport: getViewportWidth(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  changeViewportWidth: newView => dispatch(createAction_changeViewportWidth(newView)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MainLayout);

--- a/src/components/views/Homepage/Homepage.js
+++ b/src/components/views/Homepage/Homepage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import Feedback from '../../features/Feedback/FeedbackContainer';
 
 import styles from './Homepage.module.scss';
 
@@ -20,9 +20,8 @@ const Homepage = () => (
     </div>
     <FeatureBoxes />
     <NewFurniture />
+    <Feedback />
   </div>
 );
-
-// Homepage.propTypes = {};
 
 export default Homepage;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -382,6 +382,16 @@ const initialState = {
   cart: {
     products: [],
   },
+
+  ratings: [
+    {
+      person: 'John Smith',
+      occupation: 'Furniture client',
+      rating:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      image: 'https://i.postimg.cc/TP9JJgYB/managerr.png',
+    },
+  ],
 };
 
 export default initialState;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -392,6 +392,7 @@ const initialState = {
       image: 'https://i.postimg.cc/TP9JJgYB/managerr.png',
     },
   ],
+  viewport: '',
 };
 
 export default initialState;

--- a/src/redux/ratingsRedux.js
+++ b/src/redux/ratingsRedux.js
@@ -1,0 +1,8 @@
+export const getAll = ({ ratings }) => ratings; // <--- atm without  action name creator/action types/action creators
+
+/* reducer */ export default function reducer(statePart = [], action = {}) {
+  switch (action.type) {
+    default:
+      return statePart;
+  }
+}

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,6 +5,7 @@ import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
 import ratingsReducer from './ratingsRedux';
+import viewportReducer from './viewportRedux';
 
 // define reducers
 const reducers = {
@@ -12,6 +13,7 @@ const reducers = {
   categories: categoriesReducer,
   products: productsReducer,
   ratings: ratingsReducer,
+  viewport: viewportReducer,
 };
 
 // add blank reducers for initial state properties without reducers

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,12 +4,14 @@ import initialState from './initialState';
 import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
+import ratingsReducer from './ratingsRedux';
 
 // define reducers
 const reducers = {
   cart: cartReducer,
   categories: categoriesReducer,
   products: productsReducer,
+  ratings: ratingsReducer,
 };
 
 // add blank reducers for initial state properties without reducers

--- a/src/redux/viewportRedux.js
+++ b/src/redux/viewportRedux.js
@@ -1,0 +1,26 @@
+/* selectors */
+export const getViewportWidth = ({ viewportWidth }) => viewportWidth;
+
+/* action name creator */
+const reducerName = 'viewport';
+const createActionName = name => `app/${reducerName}/${name}`;
+
+/* action types */
+export const CHANGE_VIEWPORT = createActionName('CHANGE_VIEWPORT');
+
+/* action creators */
+export const createAction_changeViewportWidth = payload => ({
+  payload,
+  type: CHANGE_VIEWPORT,
+});
+
+/* reducer */
+export default function reducer(statePart = '', action = {}) {
+  switch (action.type) {
+    case CHANGE_VIEWPORT: {
+      return action.payload;
+    }
+    default:
+      return statePart;
+  }
+}


### PR DESCRIPTION
1.  Trzeba było w komponencie MainLayout w momencie podłączenia uruchomić listenera zmiany szerokości viewportu i na tej podstawie ustawić aktualny tryb (mobile, desktop, tablet) w stanie aplikacji, a następnie zastosować tę funkcjonalność w komponencie NewFurniture tak, aby na każdym trybie wyświetlała się na jednej stronie odpowiednia ilość boksów z produktami(8 na desktopie, 2 na tabletach, 1 na mobilkach).
2. W MainLayout najpierw na podstawie window.innerWidth dodałam sprawdzenie szerokości viewporta i w zależności od ustawień, żeby funkcja zwracała stringa mobile, tablet, desktop. 
Zdecydowałam się na hook useEffect, w którym:
- zdispatchowana do prosów akcja changeViewportWidth z vieportRedux.js ustawia aktualny tryb viewporta podczas podłaczenia componentu MainLayout,
 - następnie na okno ustawiony jest listener, który ma nasłuchiwać zmiany viewporta i w razie wystąpienia zmiany wywoływać handlera, którym ponownie jest changeViewportWidth aktualizujący viewport w stanie aplikacji,
- na koniec zwracana jest funkcja czyszcząca listener. Dodałam też tzw. dependencies array, chociaż niestety nie rozumiem czy jest potrzebne i do czego służy. Proszę o uwagi w tej sprawie kogoś mądrzejszego :)
wzorowałam się na przykładzie poniżej:
[https://codedaily.io/tutorials/72/Creating-a-Reusable-Window-Event-Listener-with-useEffect-and-useCallback?source=post_page---------------------------](url)
3. Zrobiłam reduksa dla viewporta oraz container dla MainLayout. Tu wzorowałam się na Search'u z projektu ToDoListy.
4.  W NewFurnitureContainer zmapowałam stan viewport a następnie w componencie NewFurniture w renderze ustaliłam ile ma się wyświetlać na stronie produktów w zależności od trybu viewport.
5.  Jeśli coś źle rozumuję proszę o poprawienie mnie, mam też wątpliwości do selektora getViewportWidth w ViewportRedux.js, myślałam że będę go używała w mapowaniu stanu, ale w rezultacie nie wydaje mi się, żeby był potrzebny, ale jak go próbuję usuwać to wszystko się sypie dlatego zostawiam. 
