### PR TITLE
add RWD to brands section - 32

### DIFF
--- a/src/components/features/Brands/Brands.js
+++ b/src/components/features/Brands/Brands.js
@@ -16,9 +16,7 @@ const Brands = ({ brands }) => {
             {brands.map(brand => (
               <div
                 key={brand.id}
-                className={
-                  'flex-row d-flex flex-wrap col-lg-2 col-md-4 col-6  ' + styles.logo
-                }
+                className={'flex-row d-flex flex-wrap col-6  ' + styles.logo}
               >
                 <img src={brand.logo} alt={brand.name} />
               </div>

--- a/src/components/features/Brands/Brands.js
+++ b/src/components/features/Brands/Brands.js
@@ -14,7 +14,12 @@ const Brands = ({ brands }) => {
           </div>
           <div className={styles.logoBox}>
             {brands.map(brand => (
-              <div key={brand.id} className={styles.logo}>
+              <div
+                key={brand.id}
+                className={
+                  'flex-row d-flex flex-wrap col-lg-2 col-md-4 col-6  ' + styles.logo
+                }
+              >
                 <img src={brand.logo} alt={brand.name} />
               </div>
             ))}

--- a/src/components/features/Brands/Brands.js
+++ b/src/components/features/Brands/Brands.js
@@ -16,7 +16,7 @@ const Brands = ({ brands }) => {
             {brands.map(brand => (
               <div
                 key={brand.id}
-                className={'flex-row d-flex flex-wrap col-6  ' + styles.logo}
+                className={'flex-row d-flex flex-wrap col-6 ' + styles.logo}
               >
                 <img src={brand.logo} alt={brand.name} />
               </div>

--- a/src/components/features/Brands/Brands.module.scss
+++ b/src/components/features/Brands/Brands.module.scss
@@ -38,14 +38,23 @@
       display: flex;
       justify-content: space-between;
       width: 100%;
-      padding: 0 30px;
+      padding: 0 10px;
       overflow: hidden;
 
       .logo {
         height: 92px;
-        width: 142px;
+        max-width: 152px;
         border: 2px solid $newFurniture-line;
         padding: 10px;
+        margin: 0 10px;
+
+        @media (max-width: 992px) {
+          min-width: 185px;
+        }
+
+        @media (max-width: 767px) {
+          min-width: 200px;
+        }
 
 
         img {

--- a/src/components/features/Brands/Brands.module.scss
+++ b/src/components/features/Brands/Brands.module.scss
@@ -39,12 +39,14 @@
       justify-content: space-between;
       width: 100%;
       padding: 0 30px;
+      overflow: hidden;
 
       .logo {
         height: 92px;
         width: 142px;
         border: 2px solid $newFurniture-line;
         padding: 10px;
+
 
         img {
           object-fit: contain;

--- a/src/components/features/Brands/Brands.module.scss
+++ b/src/components/features/Brands/Brands.module.scss
@@ -49,13 +49,16 @@
         margin: 0 10px;
 
         @media (max-width: 992px) {
-          min-width: 185px;
+          min-width: calc(33.33% - 20px);
         }
 
         @media (max-width: 767px) {
-          min-width: 200px;
+          min-width: calc(50% - 20px);
         }
 
+        @media (max-width: 560px) {
+          min-width: calc(100% - 20px);
+        }
 
         img {
           object-fit: contain;


### PR DESCRIPTION
Dodałem RWD to sekcji "brands" (6 na desktop, 3 na tablecie i 2 na mobilce)
Zdanie wyglądało następująco:

> Zadaniem jest stworzenie wersji mobilnych sekcji "Brands". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
> 
> W sliderze ma być tyle elementów, ile zmieści się w całości na danej szerokości ekranu.

Na funkcjonalność slidera jest inny ticket: 
https://projects.kodilla.com/secure/RapidBoard.jspa?rapidView=99&view=detail&selectedIssue=WDP200601-31

